### PR TITLE
Changes to pass sideNavContent property to SideNav component

### DIFF
--- a/src/Layout03.js
+++ b/src/Layout03.js
@@ -10,12 +10,17 @@ class Layout03 extends React.Component {
       <div>
         <GlobalHeader />
         <PageHeader />
-        <SideNav content="Text" />
+        <SideNav content={this.props.sideNavContent} />
         <div>{this.props.children}</div>
       </div>
     );
   }
 }
-Layout03.propTypes = { children: PropTypes };
+
+Layout03.propTypes = {
+   sideNavContent: PropTypes.object.isRequired,
+   children: PropTypes 
+};
+
 Layout03.defaultProps = {};
 export default Layout03;

--- a/stories/components/Layout03.js
+++ b/stories/components/Layout03.js
@@ -2,6 +2,31 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import Layout03 from '../../src/Layout03';
 
-const Layout03Story = () => <Layout03 />;
+const sideNavContent = [
+      {
+        type: 'navLinks',
+        navItems: [
+          {
+            type: 'navLink',
+            text: 'Tommy Cambell',
+            href: '#tom',
+            preIcon: 'fa fa-user',
+          },
+          {
+            type: 'navLink',
+            text: 'Aubrey Cambell',
+            href: '#aub',
+            preIcon: 'fa fa-user',
+          },
+          {
+            type: 'navLink',
+            text: 'Chris Cambell',
+            href: '#chris',
+            preIcon: 'fa fa-user',
+          },
+        ],
+      },
+    ];
+const Layout03Story = () => <Layout03 sideNavContent={sideNavContent}/>;
 
 storiesOf('Components', module).add('Layout03', Layout03Story);


### PR DESCRIPTION
### What is changed
Layout03 refactored to have new property sideNavContent. This property is assigned to content property in SideNav component .
This way, developers using Layout03 can pass a sideNavContent property used in rendering SideNav content.

Please note that these changes will be effective only with changes part of pull request https://github.com/ca-cwds/react-wood-duck/pull/35