### PR TITLE
Passing eslint command directly to Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,7 @@ node {
       }
       app.withRun("-e CI=true") { container ->
         stage('Lint') {
-          sh "docker exec -t ${container.id} yarn lint"
+          sh "docker exec -t ${container.id} yarn eslint ./{src,stories} "
         }
         stage('Unit Test') {
           sh "docker exec -t ${container.id} yarn run test"


### PR DESCRIPTION
This is a fix because currently, eslint is passing because it is not in the context of running in docker.  Could also change the package.json file, but hoping to hash that out in the review process.