### PR TITLE
CALS-5237 Block Entry of Alpha Characters in Zip Codes for US Addresses

### DIFF
--- a/src/CommonAddressComponent.js
+++ b/src/CommonAddressComponent.js
@@ -75,7 +75,7 @@ export default class CommonAddressFields extends React.Component {
           type="text"
           onChange={event => this.props.onChange('zip', event.target.value)}
           maxLength={5}
-          allowCharacters={/[0-9-]/}
+          allowCharacters={/[0-9]/}
         />
         <InputComponent
           gridClassName="col-md-4"

--- a/src/CommonAddressComponent.js
+++ b/src/CommonAddressComponent.js
@@ -74,6 +74,8 @@ export default class CommonAddressFields extends React.Component {
           placeholder=""
           type="text"
           onChange={event => this.props.onChange('zip', event.target.value)}
+          maxLength={5}
+          allowCharacters={/[0-9-]/}
         />
         <InputComponent
           gridClassName="col-md-4"

--- a/src/InputComponent.js
+++ b/src/InputComponent.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { sanitizeValue } from './common/inputField';
+import { sanitizeValue } from './common/InputField';
 
 const extractErrorMessage = props => {
   let errMessage = '';

--- a/src/InputComponent.js
+++ b/src/InputComponent.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { sanitizeValue } from "./common/FieldUtils";
+import { sanitizeValue } from './common/FieldUtils';
 
 const extractErrorMessage = props => {
   let errMessage = '';

--- a/src/InputComponent.js
+++ b/src/InputComponent.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-
+import {sanitizeValue} from './common/inputField';
 const InputComponent = props => {
   let errorMessage = '';
   if (props.required || props.validationError) {
@@ -11,16 +11,12 @@ const InputComponent = props => {
     errorMessage = props.serverErrorMessage;
   }
 
-  const sanitizeValue = (string, allowRegex) => {
-    const characterArray = string.split('');
-    return characterArray
-    .filter(character => character.match(allowRegex))
-    .join('');
-  };
-
   const onChangeWrapper = event => {
     if (event.target.value && props.allowCharacters) {
-      event.target.value = sanitizeValue(event.target.value, props.allowCharacters);
+      event.target.value = sanitizeValue(
+        event.target.value,
+        props.allowCharacters
+      );
     }
     props.onChange(event);
   };
@@ -75,6 +71,6 @@ InputComponent.propTypes = {
   onChange: PropTypes.func,
   disabled: PropTypes.bool,
   maxLength: PropTypes.number,
-  allowCharacters: PropTypes.instanceOf(RegExp)
+  allowCharacters: PropTypes.instanceOf(RegExp),
 };
 export default InputComponent;

--- a/src/InputComponent.js
+++ b/src/InputComponent.js
@@ -1,30 +1,31 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { sanitizeValue } from './common/inputField';
+
+const extractErrorMessage = props => {
+  let errMessage = '';
+  if (props.required || props.validationError) {
+    errMessage = props.validationErrorMessage;
+  }
+
+  if (props.serverError) {
+    errMessage = props.serverErrorMessage;
+  }
+  return errMessage;
+};
+
+const onChangeWrapper = (event, props) => {
+  if (event.target.value && props.allowCharacters) {
+    event.target.value = sanitizeValue(
+      event.target.value,
+      props.allowCharacters
+    );
+  }
+  props.onChange(event);
+};
+
 const InputComponent = props => {
-
-  const errorMessage = () => {
-    let errMessage = '';
-    if (props.required || props.validationError) {
-      errMessage = props.validationErrorMessage;
-    }
-
-    if (props.serverError) {
-      errMessage = props.serverErrorMessage;
-    }
-    return errMessage;
-  };
-
-  const onChangeWrapper = event => {
-    if (event.target.value && props.allowCharacters) {
-      event.target.value = sanitizeValue(
-        event.target.value,
-        props.allowCharacters
-      );
-    }
-    props.onChange(event);
-  };
-
+  const errorMessage = extractErrorMessage(props);
   return (
     <div className="form-group">
       <div
@@ -40,7 +41,7 @@ const InputComponent = props => {
             type={props.type}
             placeholder={props.placeholder}
             value={props.value}
-            onChange={onChangeWrapper}
+            onChange={event => onChangeWrapper(event, props)}
             disabled={props.disabled}
             maxLength={props.maxLength}
           />

--- a/src/InputComponent.js
+++ b/src/InputComponent.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { sanitizeValue } from './common/InputField';
+import { sanitizeValue } from "./common/FieldUtils";
 
 const extractErrorMessage = props => {
   let errMessage = '';

--- a/src/InputComponent.js
+++ b/src/InputComponent.js
@@ -2,14 +2,18 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { sanitizeValue } from './common/inputField';
 const InputComponent = props => {
-  let errorMessage = '';
-  if (props.required || props.validationError) {
-    errorMessage = props.validationErrorMessage;
-  }
 
-  if (props.serverError) {
-    errorMessage = props.serverErrorMessage;
-  }
+  const errorMessage = () => {
+    let errMessage = '';
+    if (props.required || props.validationError) {
+      errMessage = props.validationErrorMessage;
+    }
+
+    if (props.serverError) {
+      errMessage = props.serverErrorMessage;
+    }
+    return errMessage;
+  };
 
   const onChangeWrapper = event => {
     if (event.target.value && props.allowCharacters) {

--- a/src/InputComponent.js
+++ b/src/InputComponent.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {sanitizeValue} from './common/inputField';
+import { sanitizeValue } from './common/inputField';
 const InputComponent = props => {
   let errorMessage = '';
   if (props.required || props.validationError) {

--- a/src/InputComponent.js
+++ b/src/InputComponent.js
@@ -3,15 +3,15 @@ import PropTypes from 'prop-types';
 import { sanitizeValue } from './common/FieldUtils';
 
 const extractErrorMessage = props => {
-  let errMessage = '';
+  let errorMessage = '';
   if (props.required || props.validationError) {
-    errMessage = props.validationErrorMessage;
+    errorMessage = props.validationErrorMessage;
   }
 
   if (props.serverError) {
-    errMessage = props.serverErrorMessage;
+    errorMessage = props.serverErrorMessage;
   }
-  return errMessage;
+  return errorMessage;
 };
 
 const onChangeWrapper = (event, props) => {

--- a/src/InputComponent.js
+++ b/src/InputComponent.js
@@ -11,6 +11,20 @@ const InputComponent = props => {
     errorMessage = props.serverErrorMessage;
   }
 
+  const sanitizeValue = (string, allowRegex) => {
+    const characterArray = string.split('');
+    return characterArray
+    .filter(character => character.match(allowRegex))
+    .join('');
+  };
+
+  const onChangeWrapper = event => {
+    if (event.target.value && props.allowCharacters) {
+      event.target.value = sanitizeValue(event.target.value, props.allowCharacters);
+    }
+    props.onChange(event);
+  };
+
   return (
     <div className="form-group">
       <div
@@ -26,7 +40,7 @@ const InputComponent = props => {
             type={props.type}
             placeholder={props.placeholder}
             value={props.value}
-            onChange={props.onChange}
+            onChange={onChangeWrapper}
             disabled={props.disabled}
             maxLength={props.maxLength}
           />
@@ -61,5 +75,6 @@ InputComponent.propTypes = {
   onChange: PropTypes.func,
   disabled: PropTypes.bool,
   maxLength: PropTypes.number,
+  allowCharacters: PropTypes.instanceOf(RegExp)
 };
 export default InputComponent;

--- a/src/common/FieldUtils.js
+++ b/src/common/FieldUtils.js
@@ -1,0 +1,14 @@
+
+const sanitizeValue = (string, allowRegex) => {
+  if (allowRegex == null) throw new Error('regex must not be null');
+  let sanitizedStr = '';
+  if (string) {
+    const characterArray = string.split('');
+    sanitizedStr = characterArray
+      .filter(character => character.match(allowRegex))
+      .join('');
+  }
+  return sanitizedStr;
+};
+
+export { sanitizeValue }

--- a/src/common/FieldUtils.js
+++ b/src/common/FieldUtils.js
@@ -1,4 +1,3 @@
-
 const sanitizeValue = (string, allowRegex) => {
   if (allowRegex == null) throw new Error('regex must not be null');
   let sanitizedStr = '';
@@ -10,5 +9,4 @@ const sanitizeValue = (string, allowRegex) => {
   }
   return sanitizedStr;
 };
-
-export { sanitizeValue }
+export { sanitizeValue };

--- a/src/common/InputField.js
+++ b/src/common/InputField.js
@@ -1,7 +1,7 @@
 import FormField from '../common/FormField';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { sanitizeValue } from "./FieldUtils";
+import { sanitizeValue } from './FieldUtils';
 
 const InputField = ({
   errors,

--- a/src/common/InputField.js
+++ b/src/common/InputField.js
@@ -1,13 +1,7 @@
 import FormField from '../common/FormField';
 import PropTypes from 'prop-types';
 import React from 'react';
-
-const sanitizeValue = (string, allowRegex) => {
-  const characterArray = string.split('');
-  return characterArray
-    .filter(character => character.match(allowRegex))
-    .join('');
-};
+import { sanitizeValue } from "./FieldUtils";
 
 const InputField = ({
   errors,
@@ -82,5 +76,4 @@ InputField.propTypes = {
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
-export { sanitizeValue };
 export default InputField;

--- a/src/common/InputField.js
+++ b/src/common/InputField.js
@@ -2,6 +2,13 @@ import FormField from '../common/FormField';
 import PropTypes from 'prop-types';
 import React from 'react';
 
+const sanitizeValue = (string, allowRegex) => {
+  const characterArray = string.split('');
+  return characterArray
+  .filter(character => character.match(allowRegex))
+  .join('');
+};
+
 const InputField = ({
   errors,
   gridClassName,
@@ -26,13 +33,6 @@ const InputField = ({
     label,
     labelClassName,
     required,
-  };
-
-  const sanitizeValue = (string, allowRegex) => {
-    const characterArray = string.split('');
-    return characterArray
-      .filter(character => character.match(allowRegex))
-      .join('');
   };
 
   const onChangeWrapper = event => {
@@ -81,4 +81,9 @@ InputField.propTypes = {
   type: PropTypes.string,
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
+
+export {
+  sanitizeValue,
+};
 export default InputField;
+

--- a/src/common/InputField.js
+++ b/src/common/InputField.js
@@ -5,8 +5,8 @@ import React from 'react';
 const sanitizeValue = (string, allowRegex) => {
   const characterArray = string.split('');
   return characterArray
-  .filter(character => character.match(allowRegex))
-  .join('');
+    .filter(character => character.match(allowRegex))
+    .join('');
 };
 
 const InputField = ({
@@ -82,8 +82,5 @@ InputField.propTypes = {
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
-export {
-  sanitizeValue,
-};
+export { sanitizeValue };
 export default InputField;
-

--- a/src/test/CommonAddressComponent_tests.js
+++ b/src/test/CommonAddressComponent_tests.js
@@ -81,6 +81,13 @@ describe('Verify Common Address Fields Component', () => {
     zipCodeField.simulate('change', { target: { value: '95833' } });
     expect(onChangeSpy).toHaveBeenCalledWith('zip', '95833');
   });
+
+  it('allows only 5 numeric characters for mailing address zip on change ', () => {
+    let zipCodeField = commonAddressComponent.find('#Residentialzip').at(0);
+    zipCodeField.simulate('change', { target: { value: 'asd958334ccc' } });
+    expect(onChangeSpy).toHaveBeenCalledWith('zip', '95833');
+  });
+
   it('verify mailing Address city change', () => {
     let cityField = commonAddressComponent.find('#Residentialcity').at(0);
     cityField.simulate('change', { target: { value: 'Sacramento' } });

--- a/src/test/InputComponent_test.js
+++ b/src/test/InputComponent_test.js
@@ -15,7 +15,7 @@ describe('Input component', () => {
     fieldClassName: 'field class name',
     placeholder: 'string ',
     value: 'enter the name',
-    onChange: onChange
+    onChange: onChange,
   };
   const instance = wrapper.instance();
   wrapper.setProps(input);

--- a/src/test/InputComponent_test.js
+++ b/src/test/InputComponent_test.js
@@ -4,6 +4,7 @@ import { shallow } from 'enzyme';
 import './EnzymeSetup';
 
 describe('Input component', () => {
+  const onChange = jasmine.createSpy('onChange');
   const wrapper = shallow(<InputComponent />);
   const input = {
     id: '123ASD',
@@ -14,6 +15,7 @@ describe('Input component', () => {
     fieldClassName: 'field class name',
     placeholder: 'string ',
     value: 'enter the name',
+    onChange: onChange
   };
   const instance = wrapper.instance();
   wrapper.setProps(input);
@@ -72,5 +74,16 @@ describe('Input component', () => {
         .at(0)
         .props().value
     ).toEqual(input.value);
+  });
+
+  it('sanitizes the call to onChange when an allowCharacters pattern is given', () => {
+    wrapper.setProps({ allowCharacters: /[a-zA-Z\s-]/ });
+    const inputElement = wrapper.find('input');
+    inputElement.simulate('change', {
+      target: { value: 'hola mu-ndo239847%^#@$?' },
+    });
+    expect(onChange).toHaveBeenCalledWith({
+      target: { value: 'hola mu-ndo' },
+    });
   });
 });

--- a/src/test/common/FieldUtils_test.js
+++ b/src/test/common/FieldUtils_test.js
@@ -1,0 +1,22 @@
+import { sanitizeValue } from "../../common/FieldUtils";
+
+describe('Field utils', () => {
+  describe('Sanitize Value', ()=>{
+    it('Value not null', () => {
+      expect(sanitizeValue('a1234a', "[0-9]")).toBe('1234');
+    });
+
+    it('Value is empty', () => {
+      expect(sanitizeValue('', "/[0-9]/")).toBe('');
+    });
+
+    it('Value is null', () => {
+      expect(sanitizeValue(null, "/[0-9]/")).toBe('');
+    });
+
+    it('Regex null', () => {
+      expect(() => { sanitizeValue('', null) }).toThrow(new Error('regex must not be null'));
+    });
+  });
+});
+

--- a/src/test/common/FieldUtils_test.js
+++ b/src/test/common/FieldUtils_test.js
@@ -16,7 +16,7 @@ describe('Field utils', () => {
 
     it('Regex null', () => {
       expect(() => {
-        sanitizeValue('', null)
+        sanitizeValue('', null);
       }).toThrow(new Error('regex must not be null'));
     });
   });

--- a/src/test/common/FieldUtils_test.js
+++ b/src/test/common/FieldUtils_test.js
@@ -7,7 +7,7 @@ describe('FieldУtils', () => {
         expect(sanitizeValue('a1234a', '[0-9]')).toBe('1234');
       });
     });
-    describe('When provides an empty value', ()=>{
+    describe('When provides an empty value', () => {
       it('returns empty string', () => {
         expect(sanitizeValue('', '[0-9]')).toBe('');
       });
@@ -22,14 +22,14 @@ describe('FieldУtils', () => {
         expect(sanitizeValue(undefined, '[0-9]')).toBe('');
       });
     });
-    describe('When provides regexp as null', ()=>{
+    describe('When provides regexp as null', () => {
       it('Throws error', () => {
         expect(() => {
           sanitizeValue('', null);
         }).toThrow(new Error('regex must not be null'));
       });
     });
-    describe('When provides regexp as undefined', ()=>{
+    describe('When provides regexp as undefined', () => {
       it('Throws error', () => {
         expect(() => {
           sanitizeValue('', undefined);

--- a/src/test/common/FieldUtils_test.js
+++ b/src/test/common/FieldUtils_test.js
@@ -1,23 +1,40 @@
 import { sanitizeValue } from '../../common/FieldUtils';
 
-describe('Field utils', () => {
-  describe('Sanitize Value', () => {
-    it('Value not null', () => {
-      expect(sanitizeValue('a1234a', '[0-9]')).toBe('1234');
+describe('FieldУtils', () => {
+  describe('#santizeValue', () => {
+    describe('When provide a string value', () => {
+      it('returns sanitised result', () => {
+        expect(sanitizeValue('a1234a', '[0-9]')).toBe('1234');
+      });
     });
-
-    it('Value is empty', () => {
-      expect(sanitizeValue('', '[0-9]')).toBe('');
+    describe('When provides an empty value', ()=>{
+      it('returns empty string', () => {
+        expect(sanitizeValue('', '[0-9]')).toBe('');
+      });
     });
-
-    it('Value is null', () => {
-      expect(sanitizeValue(null, '[0-9]')).toBe('');
+    describe('When provides a null', () => {
+      it('returns empty string', () => {
+        expect(sanitizeValue(null, '[0-9]')).toBe('');
+      });
     });
-
-    it('Regex null', () => {
-      expect(() => {
-        sanitizeValue('', null);
-      }).toThrow(new Error('regex must not be null'));
+    describe('When provides a undefined', () => {
+      it('returns empty string', () => {
+        expect(sanitizeValue(undefined, '[0-9]')).toBe('');
+      });
+    });
+    describe('When provides regexp as null', ()=>{
+      it('Throws error', () => {
+        expect(() => {
+          sanitizeValue('', null);
+        }).toThrow(new Error('regex must not be null'));
+      });
+    });
+    describe('When provides regexp as undefined', ()=>{
+      it('Throws error', () => {
+        expect(() => {
+          sanitizeValue('', undefined);
+        }).toThrow(new Error('regex must not be null'));
+      });
     });
   });
 });

--- a/src/test/common/FieldUtils_test.js
+++ b/src/test/common/FieldUtils_test.js
@@ -1,22 +1,23 @@
-import { sanitizeValue } from "../../common/FieldUtils";
+import { sanitizeValue } from '../../common/FieldUtils';
 
 describe('Field utils', () => {
-  describe('Sanitize Value', ()=>{
+  describe('Sanitize Value', () => {
     it('Value not null', () => {
-      expect(sanitizeValue('a1234a', "[0-9]")).toBe('1234');
+      expect(sanitizeValue('a1234a', '[0-9]')).toBe('1234');
     });
 
     it('Value is empty', () => {
-      expect(sanitizeValue('', "/[0-9]/")).toBe('');
+      expect(sanitizeValue('', '[0-9]')).toBe('');
     });
 
     it('Value is null', () => {
-      expect(sanitizeValue(null, "/[0-9]/")).toBe('');
+      expect(sanitizeValue(null, '[0-9]')).toBe('');
     });
 
     it('Regex null', () => {
-      expect(() => { sanitizeValue('', null) }).toThrow(new Error('regex must not be null'));
+      expect(() => {
+        sanitizeValue('', null)
+      }).toThrow(new Error('regex must not be null'));
     });
   });
 });
-


### PR DESCRIPTION
Story: https://osi-cwds.atlassian.net/browse/CALS-5237

Description:
The allowCharacters functionality was added to InputComponent (the same as in the InputField)
Zip field in the CommonAddressComponent was changed to allow only numeric characters and the max length set to 5

Tests:
Unit tests were added for InputComponent and CommonAddressComponent
